### PR TITLE
overflowing_literals false positive

### DIFF
--- a/src/coordinate/mod.rs
+++ b/src/coordinate/mod.rs
@@ -524,7 +524,7 @@ impl Coordinate {
 
     fn set_prunning(arr: &mut [i8], i: usize, value: i8) {
         if i & 1 == 0 {
-            arr[i / 2] &= 0xf0 | value;
+            arr[i / 2] &= (0xf0_u8 as i8) | value;
         } else {
             arr[i / 2] &= 0x0f | (value << 4);
         }


### PR DESCRIPTION
In a future version of Rust the `overflowing_literals` lint will become deny by default. See rust-lang/rust#55632. When checking for breakage in crates uploaded to crates.io it was discovered that this crate will no longer compile thanks to this lint. The error produced is [here](https://crater-reports.s3.amazonaws.com/pr-55632/try%23dc13be39fae8d4c607889b27de374b52586485a3/gh/Vallium.rubik-rs/log.txt). This PR should fix the false positive.